### PR TITLE
ADD: Re-Subscription, FIX: subscription timeout, FIX: RenderingControl(memory leak), FIX: ZoneGroupTopology-param name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 *.so
 
 # Folders
-_obj
-_test
+_obj/
+_test/
+.idea/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/browse.go
+++ b/browse.go
@@ -31,8 +31,8 @@
 package sonos
 
 import (
-	"github.com/rclancey/go-sonos/model"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/model"
+	"github.com/esoutham1/go-sonos/upnp"
 	"log"
 	"strings"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-//
 // A module to support bookmarking discovered UPnP devices.
 //
 // This module is intended to solve the problem of addressing commands to
@@ -50,21 +49,18 @@
 // static UUID.
 //
 // Look at sonos_test.go for examples of how this class is used.
-//
 package config
 
 import (
 	"encoding/json"
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"io"
 	"log"
 	"os"
 	"path"
 )
 
-//
 // A container for the runtime configuration used by go-sonos application.
-//
 type Config struct {
 	// The path to the configuration directory
 	dirname string
@@ -74,10 +70,8 @@ type Config struct {
 	Bookmarks Bookmarks
 }
 
-//
 // A strucutre that holds all of the fields required to build a UPnP
 // device without first trying to discover it.
-//
 type Bookmark struct {
 	// A memorable string standing in for a UUID
 	Alias string `json:"alias,omitempty"`
@@ -91,10 +85,8 @@ type Bookmark struct {
 	UUID ssdp.UUID `json:"uuid"`
 }
 
-//
 // A map holding a set of bookmarks, where the key is alternately the
 // UUID of the device, or an alias to a device.
-//
 type Bookmarks map[string]Bookmark
 
 type configDevice struct {
@@ -132,20 +124,16 @@ func (this *configDevice) Services() (keys []ssdp.ServiceKey) {
 	return
 }
 
-//
 // Create a configuration object where @dir is the path to the
 // configuration directory.  Note that Init() must be called in order to
 // use the newly created object.
-//
 func MakeConfig(dir string) *Config {
 	return &Config{dir, nil, Bookmarks{}}
 }
 
-//
 // Initialize the configuration object by loading any existing
 // configuration from disk.  This method creates the configuration directory,
 // if needed.
-//
 func (this *Config) Init() {
 	var err error
 	if this.dir, err = os.Open(this.dirname); nil != err {
@@ -167,9 +155,7 @@ func (this *Config) Init() {
 	this.loadFromDisk()
 }
 
-//
 // Write the current configuration to disk.
-//
 func (this *Config) Save() {
 	if nil == this.dir {
 		return
@@ -189,13 +175,11 @@ func (this *Config) saveBookmarks() {
 	}
 }
 
-//
 // Add a bookmark to the bookmark set where @ident is either the uuid
 // or the alias to add; @product is the product string, such as 'Sonos';
 // @localtion is the network location of the resource; and @uuid is the
 // device's UUID.  When adding a device @ident and @uuid should be the same;
 // when adding an alias @ident and @uuid will be different.
-//
 func (this *Config) AddBookmark(ident, product, productVersion string, location ssdp.Location, uuid ssdp.UUID) {
 	if ident != string(uuid) {
 		this.Bookmarks[ident] = Bookmark{ident, product, productVersion, location, uuid}
@@ -204,17 +188,13 @@ func (this *Config) AddBookmark(ident, product, productVersion string, location 
 	}
 }
 
-//
 // Add @alias as an alias for @uuid.
-//
 func (this *Config) AddAlias(uuid ssdp.UUID, alias string) {
 	old := this.Bookmarks[string(uuid)]
 	this.AddBookmark(alias, "", "", ssdp.Location(""), old.UUID)
 }
 
-//
 // Remove all aliases from the set of bookmarks.
-//
 func (this *Config) ClearAliases() {
 	for key, rec := range this.Bookmarks {
 		if 0 < len(rec.Alias) {
@@ -223,10 +203,8 @@ func (this *Config) ClearAliases() {
 	}
 }
 
-//
 // Remove any association of a device to the alias @alias.  If @alias
 // is a UUID this method is a noop.
-//
 func (this *Config) ClearAlias(alias string) {
 	if rec, has := this.Bookmarks[alias]; has {
 		if 0 < len(rec.Alias) {
@@ -288,10 +266,8 @@ func (this *Config) lookupImpl(ident string, history map[string]bool) (dev ssdp.
 	return
 }
 
-//
 // Try to find the device associated with the UUID or alias
 // @ident. Returns nil if there is no device associated with @ident.
-//
 func (this *Config) Lookup(ident string) ssdp.Device {
 	return this.lookupImpl(ident, map[string]bool{})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,7 +54,7 @@ func TestConfig(t *testing.T) {
 
 	c := config.MakeConfig(configdir)
 	c.Init()
-	c.AddBookmark(uuid, sonos.SONOS, location, uuid)
+	c.AddBookmark(uuid, sonos.SONOS, "0.3.0", location, uuid)
 	c.AddAlias(uuid, alias)
 	c.Save()
 	c = nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,8 +31,8 @@
 package config_test
 
 import (
-	"github.com/rclancey/go-sonos"
-	"github.com/rclancey/go-sonos/config"
+	"github.com/esoutham1/go-sonos"
+	"github.com/esoutham1/go-sonos/config"
 	"log"
 	"os"
 	"testing"

--- a/coverage.go
+++ b/coverage.go
@@ -32,7 +32,7 @@ package sonos
 
 import (
 	"fmt"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/upnp"
 	"log"
 	"reflect"
 )

--- a/cscl/cscl.go
+++ b/cscl/cscl.go
@@ -169,7 +169,7 @@ type Args struct {
 }
 
 func Usage() {
-	fmt.Fprintf(os.Stderr, "usage: cscl [-S <uuid/alias>] [-C <configdir=~/.go-sonos/>] [-D <discovery device=eth0>]\n")
+	fmt.Fprintf(os.Stderr, "usage: cscl [-S <uuid/alias>] [-C <configdir=~/.go-sonos/>] [-D <discovery device=en0>]\n")
 	fmt.Fprintf(os.Stderr, "            [-P <discovery port=13104>]\n")
 	fmt.Fprintf(os.Stderr, "            [--help|--usage]\n")
 	fmt.Fprintf(os.Stderr, "            <command> [args ...]\n\n")
@@ -187,8 +187,8 @@ func main() {
 	args := Args{}
 	args.alias = flag.String("S", "", "device alias name")
 	args.configDir = flag.String("C", "", "go-sonos configuration directory")
-	args.discoveryDevice = flag.String("D", "eth0", "discovery device")
-	args.discoveryPort = flag.Int("P", 13104, "discovery response port")
+	args.discoveryDevice = flag.String("D", "en0", "discovery device")
+	args.discoveryPort = flag.Int("P", 0, "discovery response port")
 	args.help = flag.Bool("help", false, "show the usage message")
 	args.usage = flag.Bool("usage", false, "show the usage message")
 	flag.Usage = Usage

--- a/cscl/cscl.go
+++ b/cscl/cscl.go
@@ -28,20 +28,18 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-//
 // A client to demonstrate controlling Sonos from the command line.
 //
 // cscl := (c)ontrol (s)onos from the (c)ommand (l)ine
-//
 package main
 
 import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/rclancey/go-sonos"
-	"github.com/rclancey/go-sonos/config"
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos"
+	"github.com/esoutham1/go-sonos/config"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
 	"os"
 	"path"

--- a/csweb/csweb.go
+++ b/csweb/csweb.go
@@ -28,21 +28,19 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-//
 // A server to demonstrate controlling Sonos from a web browser.
 //
 // csweb := (c)ontrol (s)onos from a (web) browser
-//
 package main
 
 import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/rclancey/go-sonos"
-	"github.com/rclancey/go-sonos/config"
-	"github.com/rclancey/go-sonos/model"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos"
+	"github.com/esoutham1/go-sonos/config"
+	"github.com/esoutham1/go-sonos/model"
+	"github.com/esoutham1/go-sonos/upnp"
 	"log"
 	"net/http"
 	"os"
@@ -100,9 +98,7 @@ func reply(w http.ResponseWriter, err error, value interface{}) {
 
 type handlerFunc func(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error
 
-//
 // get-position-info
-//
 func handle_GetPositionInfo(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if info, err := s.GetPositionInfo(0); nil != err {
 		return err
@@ -112,9 +108,7 @@ func handle_GetPositionInfo(s *sonos.Sonos, w http.ResponseWriter, r *http.Reque
 	return nil
 }
 
-//
 // get-transport-info
-//
 func handle_GetTransportInfo(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if info, err := s.GetTransportInfo(0); nil != err {
 		return err
@@ -124,9 +118,7 @@ func handle_GetTransportInfo(s *sonos.Sonos, w http.ResponseWriter, r *http.Requ
 	return nil
 }
 
-//
 // get-volume
-//
 func handle_GetVolume(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if volume, err := s.GetVolume(0, upnp.Channel_Master); nil != err {
 		return err
@@ -136,9 +128,7 @@ func handle_GetVolume(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) er
 	return nil
 }
 
-//
 // next
-//
 func handle_Next(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if err := s.Next(0); nil != err {
 		return err
@@ -147,9 +137,7 @@ func handle_Next(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-//
 // next-section
-//
 func handle_NextSection(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if err := s.NextSection(0); nil != err {
 		return err
@@ -158,9 +146,7 @@ func handle_NextSection(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) 
 	return nil
 }
 
-//
 // pause
-//
 func handle_Pause(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if err := s.Pause(0); nil != err {
 		return err
@@ -169,9 +155,7 @@ func handle_Pause(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error 
 	return nil
 }
 
-//
 // play
-//
 func handle_Play(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if err := s.Play(0, "1"); nil != err {
 		return err
@@ -180,9 +164,7 @@ func handle_Play(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-//
 // previous
-//
 func handle_Previous(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if err := s.Previous(0); nil != err {
 		return err
@@ -191,9 +173,7 @@ func handle_Previous(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) err
 	return nil
 }
 
-//
 // previous-section
-//
 func handle_PreviousSection(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if err := s.PreviousSection(0); nil != err {
 		return err
@@ -202,9 +182,7 @@ func handle_PreviousSection(s *sonos.Sonos, w http.ResponseWriter, r *http.Reque
 	return nil
 }
 
-//
 // remove-track-from-queue
-//
 func handle_RemoveTrackFromQueue(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	track_s := r.FormValue("track")
 	if err := s.RemoveTrackFromQueue(0, fmt.Sprintf("Q:0/%s", track_s), 0); nil != err {
@@ -214,9 +192,7 @@ func handle_RemoveTrackFromQueue(s *sonos.Sonos, w http.ResponseWriter, r *http.
 	return nil
 }
 
-//
 // seek
-//
 func handle_Seek(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	unit := r.FormValue("unit")
 	target := r.FormValue("target")
@@ -227,9 +203,7 @@ func handle_Seek(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-//
 // set-volume
-//
 func handle_SetVolume(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	volume_s := r.FormValue("value")
 	if volume, err := strconv.ParseInt(volume_s, 10, 16); nil != err {
@@ -243,9 +217,7 @@ func handle_SetVolume(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) er
 	return nil
 }
 
-//
 // stop
-//
 func handle_Stop(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if err := s.Stop(0); nil != err {
 		return err
@@ -265,9 +237,9 @@ var controlHandlerMap = map[string]handlerFunc{
 	"previous":                handle_Previous,
 	"previous-section":        handle_PreviousSection,
 	"remove-track-from-queue": handle_RemoveTrackFromQueue,
-	"seek":       handle_Seek,
-	"set-volume": handle_SetVolume,
-	"stop":       handle_Stop,
+	"seek":                    handle_Seek,
+	"set-volume":              handle_SetVolume,
+	"stop":                    handle_Stop,
 }
 
 func handleControl(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) {
@@ -282,9 +254,7 @@ func handleControl(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//
 // get-album-tracks
-//
 func handle_GetAlbumTracks(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if tracks, err := s.GetAlbumTracks(r.FormValue("album")); nil != err {
 		return err
@@ -294,9 +264,7 @@ func handle_GetAlbumTracks(s *sonos.Sonos, w http.ResponseWriter, r *http.Reques
 	return nil
 }
 
-//
 // get-all-genres
-//
 func handle_GetAllGenres(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if list, err := s.GetAllGenres(); nil != err {
 		return err
@@ -306,9 +274,7 @@ func handle_GetAllGenres(s *sonos.Sonos, w http.ResponseWriter, r *http.Request)
 	return nil
 }
 
-//
 // get-artist-albums
-//
 func handle_GetArtistAlbums(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if list, err := s.GetArtistAlbums(r.FormValue("artist")); nil != err {
 		return err
@@ -318,9 +284,7 @@ func handle_GetArtistAlbums(s *sonos.Sonos, w http.ResponseWriter, r *http.Reque
 	return nil
 }
 
-//
 // get-direct-children
-//
 func handle_GetDirectChildren(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if list, err := s.GetDirectChildren(r.FormValue("root")); nil != err {
 		return err
@@ -330,9 +294,7 @@ func handle_GetDirectChildren(s *sonos.Sonos, w http.ResponseWriter, r *http.Req
 	return nil
 }
 
-//
 // get-genre-artists
-//
 func handle_GetGenreArtists(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if artists, err := s.GetGenreArtists(r.FormValue("genre")); nil != err {
 		return err
@@ -342,9 +304,7 @@ func handle_GetGenreArtists(s *sonos.Sonos, w http.ResponseWriter, r *http.Reque
 	return nil
 }
 
-//
 // get-queue-contents
-//
 func handle_GetQueueContents(s *sonos.Sonos, w http.ResponseWriter, r *http.Request) error {
 	if queue, err := s.GetQueueContents(); nil != err {
 		return err

--- a/csweb/csweb.go
+++ b/csweb/csweb.go
@@ -49,11 +49,11 @@ import (
 )
 
 const (
-	CSWEB_CONFIG        = "/home/ianr/.go-sonos"
+	CSWEB_CONFIG        = "/dot_go-sonos"
 	CSWEB_DEVICE        = "kitchen"
-	CSWEB_DISCOVER_PORT = "13104"
-	CSWEB_EVENTING_PORT = "13105"
-	CSWEB_NETWORK       = "eth0"
+	CSWEB_DISCOVER_PORT = "0"
+	CSWEB_EVENTING_PORT = "13100"
+	CSWEB_NETWORK       = "en0"
 	CSWEB_HTTP_PORT     = 8080
 )
 

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -1,4 +1,3 @@
-//
 // go-sonos
 // ========
 //
@@ -9,9 +8,9 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//   * Redistributions of source code must retain the above copyright notice,
+//   - Redistributions of source code must retain the above copyright notice,
 //     this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright
+//   - Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
 //
@@ -26,12 +25,11 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 package main
 
 import (
-	"github.com/rclancey/go-sonos"
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
 )
 

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -42,7 +42,7 @@ func main() {
 	log.Print("go-sonos example discovery\n")
 
 	mgr := ssdp.MakeManager()
-	mgr.Discover("eth0", "11209", false)
+	mgr.Discover("en0", "11209", false)
 	qry := ssdp.ServiceQueryTerms{
 		ssdp.ServiceKey("schemas-upnp-org-ContentDirectory"): -1,
 	}

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -31,6 +31,7 @@ import (
 	"github.com/esoutham1/go-sonos"
 	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
+	"runtime"
 )
 
 const (
@@ -40,9 +41,14 @@ const (
 // This code locates a content directory device on the network
 func main() {
 	log.Print("go-sonos example discovery\n")
+	ethernetInterfaceName := "eth0"
+	goos := runtime.GOOS
+	if goos == "darwin" {
+		ethernetInterfaceName = "en0" //first ethernet adapter on MacOS
+	}
 
 	mgr := ssdp.MakeManager()
-	mgr.Discover("en0", "11209", false)
+	mgr.Discover(ethernetInterfaceName, "11209", false)
 	qry := ssdp.ServiceQueryTerms{
 		ssdp.ServiceKey("schemas-upnp-org-ContentDirectory"): -1,
 	}

--- a/examples/composers/composers.go
+++ b/examples/composers/composers.go
@@ -1,4 +1,3 @@
-//
 // go-sonos
 // ========
 //
@@ -9,9 +8,9 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//   * Redistributions of source code must retain the above copyright notice,
+//   - Redistributions of source code must retain the above copyright notice,
 //     this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright
+//   - Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
 //
@@ -26,12 +25,11 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 package main
 
 import (
-	"github.com/rclancey/go-sonos"
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
 )
 

--- a/examples/composers/composers.go
+++ b/examples/composers/composers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/esoutham1/go-sonos"
 	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
+	"runtime"
 )
 
 const (
@@ -41,8 +42,13 @@ const (
 func main() {
 	log.Print("go-sonos example discovery\n")
 
+	ethernetInterfaceName := "eth0"
+	goos := runtime.GOOS
+	if goos == "darwin" {
+		ethernetInterfaceName = "en0" //first ethernet adapter on MacOS
+	}
 	mgr := ssdp.MakeManager()
-	mgr.Discover("eth0", "11209", false)
+	mgr.Discover(ethernetInterfaceName, "0", false)
 	qry := ssdp.ServiceQueryTerms{
 		ssdp.ServiceKey("schemas-upnp-org-ContentDirectory"): -1,
 	}

--- a/examples/devices/devices.go
+++ b/examples/devices/devices.go
@@ -30,14 +30,20 @@ package main
 import (
 	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
+	"runtime"
 )
 
 // This code identifies lists all UPnP devices discovered
 func main() {
 	log.Print("go-sonos example discovery\n")
+	ethernetInterfaceName := "eth0"
+	goos := runtime.GOOS
+	if goos == "darwin" {
+		ethernetInterfaceName = "en0" //first ethernet adapter on MacOS
+	}
 
 	mgr := ssdp.MakeManager()
-	mgr.Discover("eth0", "11209", false)
+	mgr.Discover(ethernetInterfaceName, "0", false)
 	i := 0
 	dev_map := mgr.Devices()
 	for _, dev := range dev_map {

--- a/examples/devices/devices.go
+++ b/examples/devices/devices.go
@@ -1,4 +1,3 @@
-//
 // go-sonos
 // ========
 //
@@ -9,9 +8,9 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//   * Redistributions of source code must retain the above copyright notice,
+//   - Redistributions of source code must retain the above copyright notice,
 //     this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright
+//   - Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
 //
@@ -26,11 +25,10 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 package main
 
 import (
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
 )
 

--- a/examples/discovery/discovery.go
+++ b/examples/discovery/discovery.go
@@ -30,20 +30,25 @@ package main
 import (
 	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
+	"runtime"
 )
 
 // This code identifies UPnP devices on the netork that support the
 // MusicServices API.
 func main() {
 	log.Print("go-sonos example discovery\n")
-
+	ethernetInterfaceName := "eth0"
+	goos := runtime.GOOS
+	if goos == "darwin" {
+		ethernetInterfaceName = "en0" //first ethernet adapter on MacOS
+	}
 	mgr := ssdp.MakeManager()
 
 	// Discover()
-	//  eth0 := Network device to query for UPnP devices
-	// 11209 := Free local port for discovery replies
+	//  eth0 or en0 := Network interface to query for UPnP devices
+	// 0 := Free random assigned local port for discovery replies
 	// false := Do not subscribe for asynchronous updates
-	mgr.Discover("eth0", "11209", false)
+	mgr.Discover(ethernetInterfaceName, "0", false)
 
 	// SericeQueryTerms
 	// A map of service keys to minimum required version

--- a/examples/discovery/discovery.go
+++ b/examples/discovery/discovery.go
@@ -1,4 +1,3 @@
-//
 // go-sonos
 // ========
 //
@@ -9,9 +8,9 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//   * Redistributions of source code must retain the above copyright notice,
+//   - Redistributions of source code must retain the above copyright notice,
 //     this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright
+//   - Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
 //
@@ -26,11 +25,10 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 package main
 
 import (
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
 )
 

--- a/examples/googletv/googletv.go
+++ b/examples/googletv/googletv.go
@@ -1,4 +1,3 @@
-//
 // go-sonos
 // ========
 //
@@ -9,9 +8,9 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//   * Redistributions of source code must retain the above copyright notice,
+//   - Redistributions of source code must retain the above copyright notice,
 //     this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright
+//   - Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
 //
@@ -26,12 +25,11 @@
 // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
 package main
 
 import (
-	"github.com/rclancey/go-sonos"
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
 	"strings"
 )

--- a/examples/googletv/googletv.go
+++ b/examples/googletv/googletv.go
@@ -31,6 +31,7 @@ import (
 	"github.com/esoutham1/go-sonos"
 	"github.com/esoutham1/go-sonos/ssdp"
 	"log"
+	"runtime"
 	"strings"
 )
 
@@ -41,9 +42,13 @@ const (
 // This code locates a GoogleTV device on the network
 func main() {
 	log.Print("go-sonos example discovery\n")
-
+	ethernetInterfaceName := "eth0"
+	goos := runtime.GOOS
+	if goos == "darwin" {
+		ethernetInterfaceName = "en0" //first ethernet adapter on MacOS
+	}
 	mgr := ssdp.MakeManager()
-	mgr.Discover("eth0", "11209", false)
+	mgr.Discover(ethernetInterfaceName, "0", false)
 	dev_map := mgr.Devices()
 	for _, dev := range dev_map {
 		if "NSZ-GS7" == dev.Product() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rclancey/go-sonos
+module github.com/esoutham1/go-sonos
 
-go 1.13
+go 1.20

--- a/linn-co-uk/Playlist.go
+++ b/linn-co-uk/Playlist.go
@@ -32,7 +32,7 @@ package linn
 
 import (
 	"encoding/xml"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/upnp"
 )
 
 type Playlist struct {

--- a/model/message.go
+++ b/model/message.go
@@ -32,8 +32,8 @@ package model
 
 import (
 	"encoding/xml"
-	"github.com/rclancey/go-sonos/didl"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/didl"
+	"github.com/esoutham1/go-sonos/upnp"
 	"strings"
 	"time"
 )

--- a/model/model.go
+++ b/model/model.go
@@ -28,13 +28,11 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-//
 // A collection of object classes used in message passing in go-sonos.
-//
 package model
 
 import (
-	"github.com/rclancey/go-sonos/didl"
+	"github.com/esoutham1/go-sonos/didl"
 	_ "log"
 )
 
@@ -91,11 +89,9 @@ type Object interface {
 	IsContainer() bool
 }
 
-//
 // A flattened structure of exported fields to allow Objects to be passed
 // via XML, JSON, or other encoding relying on reflection.  Fields in this
 // struct mirror the usage of like-named methods in the Object interface.
-//
 type ObjectMessage struct {
 	ID          string
 	ParentID    string

--- a/reciva-com/RecivaRadio.go
+++ b/reciva-com/RecivaRadio.go
@@ -32,7 +32,7 @@ package reciva
 
 import (
 	"encoding/xml"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/upnp"
 )
 
 type RecivaRadio struct {

--- a/reciva-com/RecivaSimpleRemote.go
+++ b/reciva-com/RecivaSimpleRemote.go
@@ -32,7 +32,7 @@ package reciva
 
 import (
 	"encoding/xml"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/upnp"
 )
 
 type RecivaSimpleRemote struct {

--- a/reciva.go
+++ b/reciva.go
@@ -31,10 +31,10 @@
 package sonos
 
 import (
-	"github.com/rclancey/go-sonos/linn-co-uk"
-	"github.com/rclancey/go-sonos/reciva-com"
-	"github.com/rclancey/go-sonos/ssdp"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/linn-co-uk"
+	"github.com/esoutham1/go-sonos/reciva-com"
+	"github.com/esoutham1/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos/upnp"
 	_ "log"
 )
 

--- a/sonos.go
+++ b/sonos.go
@@ -28,14 +28,12 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-//
 // A go-language implementation of the Sonos UPnP API.
-//
 package sonos
 
 import (
-	"github.com/rclancey/go-sonos/ssdp"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos/upnp"
 	_ "log"
 )
 

--- a/sonos_test.go
+++ b/sonos_test.go
@@ -31,11 +31,11 @@
 package sonos_test
 
 import (
-	"github.com/rclancey/go-sonos"
-	"github.com/rclancey/go-sonos/config"
-	"github.com/rclancey/go-sonos/didl"
-	"github.com/rclancey/go-sonos/ssdp"
-	"github.com/rclancey/go-sonos/upnp"
+	"github.com/esoutham1/go-sonos"
+	"github.com/esoutham1/go-sonos/config"
+	"github.com/esoutham1/go-sonos/didl"
+	"github.com/esoutham1/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos/upnp"
 	"log"
 	"strings"
 	"testing"
@@ -90,9 +90,7 @@ func getTestReciva(flags int) *sonos.Reciva {
 	return testReciva
 }
 
-//
 // AlarmClock
-//
 func TestAlarmClock(t *testing.T) {
 	s := getTestSonos(sonos.SVC_ALARM_CLOCK)
 
@@ -148,9 +146,7 @@ func TestAlarmClock(t *testing.T) {
 	}
 }
 
-//
 // AVTransport
-//
 func TestAVTransport(t *testing.T) {
 	s := getTestSonos(sonos.SVC_AV_TRANSPORT)
 
@@ -239,9 +235,7 @@ func TestAVTransport(t *testing.T) {
 	*/
 }
 
-//
 // ConnectiionManager
-//
 func TestConnectionManager(t *testing.T) {
 	s := getTestSonos(sonos.SVC_CONNECTION_MANAGER)
 
@@ -258,10 +252,8 @@ func TestConnectionManager(t *testing.T) {
 	}
 }
 
-//
 // ContentDirectory
 // @see also TestBrowse
-//
 func TestContentDirectory(t *testing.T) {
 	s := getTestSonos(sonos.SVC_CONTENT_DIRECTORY)
 
@@ -308,9 +300,7 @@ func TestContentDirectory(t *testing.T) {
 	}
 }
 
-//
 // DeviceProperties
-//
 func TestDeviceProperties(t *testing.T) {
 	s := getTestSonos(sonos.SVC_DEVICE_PROPERTIES)
 
@@ -377,16 +367,12 @@ func TestDeviceProperties(t *testing.T) {
 	}
 }
 
-//
 // GroupManagement
-//
 func TestGroupManagement(t *testing.T) {
 	// TODO
 }
 
-//
 // MusicServices
-//
 func TestMusicServices(t *testing.T) {
 	s := getTestSonos(sonos.SVC_MUSIC_SERVICES)
 
@@ -409,9 +395,7 @@ func TestMusicServices(t *testing.T) {
 	}
 }
 
-//
 // RenderingControl
-//
 func TestRenderingControl(t *testing.T) {
 	s := getTestSonos(sonos.SVC_RENDERING_CONTROL)
 
@@ -489,16 +473,12 @@ func TestRenderingControl(t *testing.T) {
 	}
 }
 
-//
 // SystemProperties
-//
 func TestSystemProperties(t *testing.T) {
 	// TODO
 }
 
-//
 // ZoneGroupTopology
-//
 func TestZoneGroupTopology(t *testing.T) {
 	s := getTestSonos(sonos.SVC_ZONE_GROUP_TOPOLOGY)
 
@@ -514,17 +494,13 @@ func TestZoneGroupTopology(t *testing.T) {
 	}
 }
 
-//
 // Coverage
-//
 func TestCoverage(t *testing.T) {
 	s := getTestSonos(sonos.SVC_ALL)
 	sonos.Coverage(s)
 }
 
-//
 // Discovery
-//
 func _TestDiscovery(t *testing.T) {
 	if mgr, err := sonos.Discover(TEST_NETWORK, TEST_DISCOVER_PORT); nil != err {
 		panic(err)
@@ -539,9 +515,7 @@ func _TestDiscovery(t *testing.T) {
 	}
 }
 
-//
 // Browse
-//
 func TestBrowse(t *testing.T) {
 	s := getTestSonos(sonos.SVC_CONTENT_DIRECTORY)
 
@@ -1229,9 +1203,9 @@ func TestRecivaGetTimeZone(t *testing.T) {
 	}
 }
 
-////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////
 // Issue #4
-////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////
 func read_events(c chan upnp.Event) {
 	for {
 		select {

--- a/ssdp/ssdp.go
+++ b/ssdp/ssdp.go
@@ -32,7 +32,7 @@
 // A client implementation of the SSDP protocol.
 //
 //	mgr := ssdp.MakeManager()
-//	mgr.Discover("eth0", "13104", false)
+//	mgr.Discover("en0", "13104", false)
 //	qry := ssdp.ServiceQueryTerms{
 //		ssdp.ServiceKey("schemas-upnp-org-MusicServices"): -1,
 //	}
@@ -271,25 +271,25 @@ type ssdpNotifyQueue chan *ssdpNotifyMessage
 
 type ssdpResponseMessage struct {
 	ssdpServerDescription
-	_01_nls            string
-	al                 string
-	cache_control      string
-	date               string
-	ext                string
-	location           Location
-	opt                string
-	st                 string
-	usn                string
-	x_rincon_bootseq   string
-	x_rincon_household string
-	x_rincon_variant   string
-	x_rincon_wifimode  string
-	x_user_agent       string
-	content_length     string
-	bootid_upnp_org    string
-	configid_upnp_org  string
+	_01_nls                      string
+	al                           string
+	cache_control                string
+	date                         string
+	ext                          string
+	location                     Location
+	opt                          string
+	st                           string
+	usn                          string
+	x_rincon_bootseq             string
+	x_rincon_household           string
+	x_rincon_variant             string
+	x_rincon_wifimode            string
+	x_user_agent                 string
+	content_length               string
+	bootid_upnp_org              string
+	configid_upnp_org            string
 	household_smartspeaker_audio string
-	x_av_server_info   string
+	x_av_server_info             string
 }
 
 type ssdpResponseQueue chan *ssdpResponseMessage
@@ -532,7 +532,7 @@ func (this *ssdpDefaultManager) ssdpHandleNotify(raw *ssdpRawMessage) *ssdpNotif
 		case "01-Nls":
 			msg._01_nls = value
 		default:
-			log.Printf("No support for field `%s' (value `%s')", key, value)
+			log.Printf("No ssdpNotify support for field `%s' (value `%s')", key, value)
 		}
 	}
 	return msg
@@ -549,6 +549,8 @@ func (this *ssdpDefaultManager) ssdpHandleResponse(raw *ssdpRawMessage) *ssdpRes
 		case "Server":
 			m := ssdpServerStringRegexp.FindStringSubmatch(value)
 			if 0 < len(m) {
+				//DBG: log.Printf("Server:%#v", m)
+
 				msg.os = m[1]
 				msg.os_version = m[3]
 				msg.upnp_version = m[5]
@@ -591,9 +593,24 @@ func (this *ssdpDefaultManager) ssdpHandleResponse(raw *ssdpRawMessage) *ssdpRes
 			msg.household_smartspeaker_audio = value
 		case "X-Av-Server-Info":
 			msg.x_av_server_info = value
+
+			//list of KNOWN unsupported messages
+		case "Securelocation.upnp.org":
+		case "X-Accepts-Registration":
+		case "X-Sonos-Hhsecurelocation":
+		case "X-Friendly-Name":
+		case "X-Mdx-Caps":
+		case "X-Mdx-Link":
+		case "X-Mdx-Registered":
+		case "X-Mdx-Remote-Login-Requested-By-Witcher":
+		case "X-Mdx-Remote-Login-Supported":
+		case "X-Msl":
+		case "X-Rincon-Proxy":
+			//DBG: log.Printf("No ssdpResponse support for %s", key)
+
 		default:
 			log.Printf("No support for field `%s' (value `%s')", key, value)
-			log.Printf("%v", raw)
+			//DBG: log.Printf("%v", raw)
 		}
 	}
 	return msg
@@ -637,7 +654,7 @@ func (this *ssdpDefaultManager) ssdpUnicastDiscoverImpl(ifi *net.Interface, port
 	for _, addr := range addrs {
 		if nil != addr.(*net.IPNet).IP.DefaultMask() {
 			lip = addr.(*net.IPNet).IP
-			break;
+			break
 		}
 	}
 	laddr, err := net.ResolveUDPAddr(ssdpBroadcastVersion, net.JoinHostPort(lip.String(), port))

--- a/upnp/ContentDirectory.go
+++ b/upnp/ContentDirectory.go
@@ -32,7 +32,7 @@ package upnp
 
 import (
 	"encoding/xml"
-	"github.com/rclancey/go-sonos/didl"
+	"github.com/esoutham1/go-sonos/didl"
 	_ "log"
 )
 
@@ -310,11 +310,9 @@ func (this *ContentDirectory) UpdateObject(objectId, currentTagValue, newTagValu
 	return
 }
 
-//
 // Remove the directory object given by @objectId (e.g. "SQ:11", to
 // remove a saved queue). A 701 error is returned if an invalid @objectId
 // is specified.
-//
 func (this *ContentDirectory) DestroyObject(objectId string) error {
 	type Response struct {
 		XMLName xml.Name

--- a/upnp/RenderingControl.go
+++ b/upnp/RenderingControl.go
@@ -93,6 +93,19 @@ type RenderingControl struct {
 }
 
 func (this *RenderingControl) BeginSet(svc *Service, channel chan Event) {
+	// Clear LastChange or else events keep appending to these fields and leaking memory
+	this.LastChange.InstanceID.Volume = nil
+	this.LastChange.InstanceID.Mute = nil
+	this.LastChange.InstanceID.Bass = nil
+	this.LastChange.InstanceID.Treble = nil
+	this.LastChange.InstanceID.Loudness = nil
+	this.LastChange.InstanceID.OutputFixed = nil
+	this.LastChange.InstanceID.HeadphoneConnected = nil
+	this.LastChange.InstanceID.SpeakerSize = nil
+	this.LastChange.InstanceID.SubGain = nil
+	this.LastChange.InstanceID.SubCrossover = nil
+	this.LastChange.InstanceID.SubPolarity = nil
+	this.LastChange.InstanceID.SubEnabled = nil
 }
 
 type renderingControlUpdate_XML struct {

--- a/upnp/ZoneGroupTopology.go
+++ b/upnp/ZoneGroupTopology.go
@@ -217,9 +217,9 @@ func (this *ZoneGroupTopology) RegisterMobileDevice(deviceName, deviceUDN, devic
 }
 
 type ZoneGroupAttributes struct {
-	CurrentZoneGroupName   string
-	CurrentZoneGroupID     string
-	ZonePlayerUUIDsInGroup string
+	CurrentZoneGroupName          string
+	CurrentZoneGroupID            string
+	CurrentZonePlayerUUIDsInGroup string
 }
 
 func (this *ZoneGroupTopology) GetZoneGroupAttributes() (*ZoneGroupAttributes, error) {

--- a/upnp/device.go
+++ b/upnp/device.go
@@ -35,7 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/esoutham1/go-sonos/ssdp"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -202,7 +202,7 @@ func (this *upnpDescribeDeviceJob) Unpack() (svc_list []*Service) {
 
 func (this *upnpDescribeDeviceJob) Parse() {
 	defer this.response.Body.Close()
-	if body, err := ioutil.ReadAll(this.response.Body); nil == err {
+	if body, err := io.ReadAll(this.response.Body); nil == err {
 		xml.Unmarshal(body, &this.doc)
 		this.result <- this.Unpack()
 	} else {

--- a/upnp/device.go
+++ b/upnp/device.go
@@ -34,7 +34,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/rclancey/go-sonos/ssdp"
+	"github.com/esoutham1/go-sonos/ssdp"
 	"io/ioutil"
 	"log"
 	"net/http"

--- a/upnp/event.go
+++ b/upnp/event.go
@@ -38,6 +38,8 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -162,11 +164,36 @@ func (this *upnpDefaultReactor) Init(ifiname, port string) {
 }
 
 func (this *upnpDefaultReactor) handleAck(svc *Service, resp *http.Response) (sid string, err error) {
-	sid_key := http.CanonicalHeaderKey("sid")
-	if sid_list, has := resp.Header[sid_key]; has {
-		sid = sid_list[0]
+	if resp.Status == "200 OK" {
+		sid_key := http.CanonicalHeaderKey("sid")
+		if sid_list, has := resp.Header[sid_key]; has {
+			sid = sid_list[0]
+			svc.ssid = sid // Save sid in the service for re-subscribe
+
+			// USE Timeout value returned to schedule reSubscribe
+			sid_timeout := http.CanonicalHeaderKey("TIMEOUT")
+			if timeout_list, has := resp.Header[sid_timeout]; has {
+				timeoutStr := timeout_list[0]
+				if strings.HasPrefix(timeoutStr, "Second-") {
+					timeoutStr = strings.TrimPrefix(timeoutStr, "Second-")
+				}
+				var timeoutVal uint64
+				timeoutVal, err = strconv.ParseUint(timeoutStr, 10, 16)
+				if err == nil {
+					svc.timeout = time.Duration(timeoutVal) * time.Second
+					//DBG: log.Printf("Sub_Timeout:%d Sec (%s)\n", timeoutVal, svc.timeout.String())
+				} else {
+					err = errors.New("subscription ack timeout failed to parse")
+				}
+			} else {
+				err = errors.New("subscription ack missing timeout")
+			}
+		} else {
+			err = errors.New("subscription ack missing sid. ")
+		}
 	} else {
-		err = errors.New("Subscription ack missing sid")
+		errStr := fmt.Sprintln("subscription ack failed: ", resp.Status)
+		err = errors.New(errStr)
 	}
 	return
 }
@@ -190,22 +217,89 @@ func (this *upnpDefaultReactor) subscribeImpl(rec *upnpEventRecord) (err error) 
 	if nil != err {
 		return
 	}
-	req.Header.Add("CALLBACK", fmt.Sprintf("<http://%s/eventSub>", this.localAddr))
 	req.Header.Add("HOST", rec.svc.eventSubURL.Host)
 	req.Header.Add("USER-AGENT", "unix/5.1 UPnP/1.1 sonos.go/1.0")
-	req.Header.Add("NT", "upnp:event")
-	req.Header.Add("TIMEOUT", "900")
+	req.Header.Add("CALLBACK", fmt.Sprintf("<http://%s/eventSub>", this.localAddr))
+	req.Header.Add("NT", "upnp:event") //Required. Field value contains Notification Type. shall be upnp:event.
+	// (No SID header field is used to subscribe.)
+	req.Header.Add("TIMEOUT", "Second-1800") //Recommended. Field value contains requested duration until subscription expires. Consists of the keyword Second- followed (without an intervening space)
 	var resp *http.Response
 	if resp, err = client.Do(req); nil == err {
 		defer resp.Body.Close()
 		var sid string
 		if sid, err = this.handleAck(rec.svc, resp); nil == err {
-			this.eventMap[sid] = rec
+			this.eventMap[sid] = rec // Save this subscription to the map
 		} else {
-			log.Println("error handling subscription ack:", err)
+			log.Println("error on subscription ack:", err)
 		}
 	} else {
 		log.Println("error subscribing:", req.URL, req.Header, err)
+	}
+	return
+}
+
+func (this *upnpDefaultReactor) reSubscribeImpl(rec *upnpEventRecord) (err error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("SUBSCRIBE", rec.svc.eventSubURL.String(), nil)
+	if nil != err {
+		return
+	}
+	req.Header.Add("HOST", rec.svc.eventSubURL.Host) // Required. Field value contains domain name or IP address and optional port components of fully qualified event subscription URL
+	req.Header.Add("USER-AGENT", "unix/5.1 UPnP/1.1 sonos.go/1.0")
+	// (No CALLBACK header field is used to renew an event subscription.)
+	// (No NT header field is used to renew an event subscription.)
+	req.Header.Add("SID", rec.svc.ssid)      // Required. Field value contains Subscription Identifier. Shall be the subscription identifier assigned by publisher in response to subscription request. Shall be universally unique. Shall begin with uuid:
+	req.Header.Add("TIMEOUT", "Second-1800") // Recommended. Field value contains requested duration until subscription expires. Consists of the keyword Second- followed (without an intervening space)
+
+	var resp *http.Response
+	if resp, err = client.Do(req); nil == err {
+		defer resp.Body.Close()
+		var sid string
+		if sid, err = this.handleAck(rec.svc, resp); nil == err {
+			this.eventMap[sid] = rec // Update the map
+		} else {
+			log.Println("error on re-subscribe ack:", err)
+			//Clear eventMap info to try full subscribe
+			rec.svc.ssid = sid  // if err, sid will be empty (try FullSubscribe later)
+			rec.svc.timeout = 0 // use default re-subscribe timeout
+		}
+	}
+
+	//IF NO Re-Subscription
+	if rec.svc.ssid == "" {
+		log.Println("error reSubscribing:", req.URL, req.Header, err)
+
+		// TRY NEW SUBSCRIPTION to recover
+		err = this.subscribeImpl(rec)
+		if err != nil {
+			log.Println("error during Subscribe recovery attempt!", err)
+			rec.svc.ssid = ""   // Clear the sid so we can try again later
+			rec.svc.timeout = 0 // use default re-subscribe timeout
+		}
+	}
+	return
+}
+
+func (this *upnpDefaultReactor) unSubscribeImpl(rec *upnpEventRecord) (err error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("UNSUBSCRIBE", rec.svc.eventSubURL.String(), nil)
+	if nil != err {
+		return
+	}
+	req.Header.Add("HOST", rec.svc.eventSubURL.Host)
+	req.Header.Add("USER-AGENT", "unix/5.1 UPnP/1.1 sonos.go/1.0")
+	// (No CALLBACK header field is used to cancel an event subscription.)
+	// (No NT header field is used to renew an event subscription.)
+	req.Header.Add("SID", rec.svc.ssid) // Required. Field value contains Subscription Identifier. Shall be the subscription identifier assigned by publisher in response to subscription request. Shall be universally unique. Shall begin with uuid:
+	// (No TIMEOUT header field is used to cancel an event subscription.)
+
+	var resp *http.Response
+	if resp, err = client.Do(req); nil == err {
+		defer resp.Body.Close()
+		sid := rec.svc.ssid
+		this.eventMap[sid] = rec
+	} else {
+		log.Println("error unSubscribing:", req.URL, req.Header, err)
 	}
 	return
 }
@@ -224,10 +318,32 @@ func (this *upnpDefaultReactor) maybePostEvent(event *upnpEvent) {
 }
 
 func (this *upnpDefaultReactor) run() {
+	var err error
 	for {
 		select {
 		case subscr := <-this.subscrChan:
-			this.subscribeImpl(subscr)
+			if subscr.svc.ssid == "" { // New-Subscription
+				err = this.subscribeImpl(subscr)
+				//DBG: log.Printf("SUBSCRIBE %s = %s : %d\n", subscr.svc.serviceId, subscr.svc.ssid, subscr.svc.timeout/time.Second)
+			} else { // Re-Subscription
+				//DBG: log.Printf("RESUBSCRIBE %s : %d\n", subscr.svc.ssid, subscr.svc.timeout/time.Second)
+				err = this.reSubscribeImpl(subscr)
+			}
+			if err != nil {
+				log.Println("error during Subscribe:", err)
+			}
+
+			// Schedule next re/Subscribe attempt
+			go func() {
+				resubscribeTime := subscr.svc.timeout / 2 // resubscribe in half the timeout time
+				if 0 == subscr.svc.timeout {
+					log.Printf("warning: Subscription timeout=0 Use 10min instead\n")
+					resubscribeTime = 10 * time.Minute
+				}
+				resTimer := time.NewTimer(resubscribeTime)
+				<-resTimer.C              // waits here for timer to expire
+				this.subscrChan <- subscr // send subscription to re-subscribe
+			}()
 		case event := <-this.unpackChan:
 			this.maybePostEvent(event)
 		}

--- a/upnp/event.go
+++ b/upnp/event.go
@@ -34,7 +34,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -273,13 +273,13 @@ func (this *upnpDefaultReactor) unpack(sid string, doc *upnpEvent_XML) {
 
 func (this *upnpDefaultReactor) handle(request *http.Request) {
 	defer request.Body.Close()
-	if body, err := ioutil.ReadAll(request.Body); nil != err {
+	if body, err := io.ReadAll(request.Body); nil != err {
 		panic(err)
 	} else {
 		sid_key := http.CanonicalHeaderKey("sid")
 		var sid string
 		if sid_list, has := request.Header[sid_key]; has {
-			//log.Println("event xml:", string(body))
+			//DBG: log.Println("event xml:", string(body))
 			sid = sid_list[0]
 			doc := &upnpEvent_XML{}
 			xml.Unmarshal(body, doc)

--- a/upnp/service.go
+++ b/upnp/service.go
@@ -34,7 +34,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -222,6 +222,13 @@ func (this *upnpDescribeServiceJob) UnpackActionList(act_list *upnpActionList_XM
 	return
 }
 
+func (this *Service) GetUdn() string {
+	return this.udn
+}
+func (this *Service) GetStruct() Service {
+	return *this
+}
+
 type Service struct {
 	deviceURI      string
 	deviceType     string
@@ -262,7 +269,7 @@ func (this *upnpDescribeServiceJob) Unpack() {
 
 func (this *upnpDescribeServiceJob) Parse() {
 	defer this.response.Body.Close()
-	if body, err := ioutil.ReadAll(this.response.Body); nil == err {
+	if body, err := io.ReadAll(this.response.Body); nil == err {
 		xml.Unmarshal(body, &this.doc)
 		this.Unpack()
 		this.result <- this.svc

--- a/upnp/service.go
+++ b/upnp/service.go
@@ -244,6 +244,8 @@ type Service struct {
 	described      bool
 	stateTable     []*upnpStateVariable
 	actionList     []*upnpAction
+	ssid           string        // save ssid for re-subscribe/unsubscribe
+	timeout        time.Duration // save timeout for re-subscribe
 }
 
 func (this *Service) Actions() (actions []string) {

--- a/upnp/soap.go
+++ b/upnp/soap.go
@@ -34,7 +34,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	_ "log"
 	"net/http"
 	_ "os"
@@ -172,7 +172,7 @@ func (this *Service) Call(action string, args Args) (response string) {
 	} else {
 		defer resp.Body.Close()
 		var body []byte
-		if body, err = ioutil.ReadAll(resp.Body); nil != err {
+		if body, err = io.ReadAll(resp.Body); nil != err {
 			panic(err)
 		}
 		doc := soapResponseEnvelope{}


### PR DESCRIPTION
Fixing the subscription events so that the event subscriptions stay alive and re-subscribe as long as it is running. I did not implement the unsubscribe method, because nothing in this library is expected to properly shutdown and unsubscribe, but with the fix to subscription-timeout everything should get cleaned-up within 30 minutes.